### PR TITLE
updates window size to handle terminal resizing

### DIFF
--- a/packages/tui-ink/src/InkTUIRenderer.tsx
+++ b/packages/tui-ink/src/InkTUIRenderer.tsx
@@ -130,9 +130,28 @@ export const InkTUIRenderer: React.FC<InkTUIRendererProps> = ({
 	const [hasAutoSelected, setHasAutoSelected] = useState(false);
 	const [tailingMap, setTailingMap] = useState<Map<string, boolean>>(new Map());
 	const {stdout} = useStdout();
+	const [dimensions, setDimensions] = useState({
+		height: stdout?.rows ?? 24,
+		width: stdout?.columns ?? 80,
+	});
 
-	const terminalHeight = stdout?.rows ?? 24;
-	const terminalWidth = stdout?.columns ?? 80;
+	useEffect(() => {
+		const handleResize = () => {
+			setDimensions({
+				height: stdout?.rows ?? 24,
+				width: stdout?.columns ?? 80,
+			});
+		};
+
+		process.stdout.on('resize', handleResize);
+
+		return () => {
+			process.stdout.off('resize', handleResize);
+		};
+	}, [stdout]);
+
+	const terminalHeight = dimensions.height;
+	const terminalWidth = dimensions.width;
 
 	const processItems: ProcessItem[] = useMemo(() => {
 		const items: ProcessItem[] = [];


### PR DESCRIPTION
This pull request improves how the `InkTUIRenderer` component handles terminal resizing by introducing a stateful approach to track terminal dimensions and updating them dynamically when the terminal is resized. This ensures that the UI remains responsive to terminal size changes.

**Terminal resize handling:**

* Added a `dimensions` state to track terminal `height` and `width`, initialized from `stdout` or default values.
* Implemented a `useEffect` hook to listen for the terminal's `'resize'` event and update the `dimensions` state accordingly, ensuring the UI updates in real time.
* Updated usages of `terminalHeight` and `terminalWidth` to derive their values from the new `dimensions` state instead of directly from `stdout`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal UI now dynamically adapts to window size changes, updating layout on resize.
  * Initial render automatically uses your current terminal dimensions for accurate sizing.
  * Smooth resizing improves readability and component alignment as the terminal is resized.
  * Sensible defaults ensure consistent display when terminal dimensions aren’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->