### PR TITLE
fix: resolve log window rendering issues with newlines and auto-scroll

### DIFF
--- a/packages/core/src/process-unit.ts
+++ b/packages/core/src/process-unit.ts
@@ -196,12 +196,22 @@ export class ProcessUnit {
 
 		if (this._process.stdout) {
 			this._process.stdout.on('data', chunk => {
-				this.logger.addChunk(chunk.toString());
+				const lines = chunk.toString().split('\n');
+				lines.forEach((line: string, index: number) => {
+					if (line || index < lines.length - 1) {
+						this.logger.addChunk(line);
+					}
+				});
 			});
 		}
 		if (this._process.stderr) {
 			this._process.stderr.on('data', chunk => {
-				this.logger.addChunk(chunk.toString(), true);
+				const lines = chunk.toString().split('\n');
+				lines.forEach((line: string, index: number) => {
+					if (line || index < lines.length - 1) {
+						this.logger.addChunk(line, true);
+					}
+				});
 			});
 
 			if (this.crashOnStderr) {

--- a/packages/tui-ink/src/InkTUIRenderer.tsx
+++ b/packages/tui-ink/src/InkTUIRenderer.tsx
@@ -242,10 +242,10 @@ export const InkTUIRenderer: React.FC<InkTUIRendererProps> = ({
 		: false;
 
 	useEffect(() => {
-		if (isTailing && logsData && logEntries.length > maxLogLines) {
+		if (isTailing && logsData) {
 			setLogScrollOffset(Math.max(0, logEntries.length - maxLogLines));
 		}
-	}, [logEntries, isTailing, logsData, maxLogLines]);
+	}, [logEntries.length, isTailing, logsData, maxLogLines]);
 
 	const visibleLogEntries = useMemo(() => {
 		const start = logScrollOffset;
@@ -302,6 +302,14 @@ export const InkTUIRenderer: React.FC<InkTUIRendererProps> = ({
 					onKeyPress('flag-enter');
 				} else if (processItems[selectedIndex]) {
 					const item = processItems[selectedIndex];
+					const processKey = `${item.type}:${item.id}`;
+					setTailingMap(prev => {
+						const newMap = new Map(prev);
+						if (!newMap.has(processKey)) {
+							newMap.set(processKey, true);
+						}
+						return newMap;
+					});
 					onKeyPress('enter', {processInfo: {id: item.id, type: item.type}});
 					setLogScrollOffset(0);
 				}


### PR DESCRIPTION
This pull request introduces improvements to how process output is handled and displayed in the TUI renderer, focusing on better log chunking and more robust log tailing behavior. The changes ensure that log lines are processed individually, which helps with accurate log rendering, and enhance the user experience when interacting with process logs in the UI.

**Process output handling:**
- Updated the `ProcessUnit` class to split both `stdout` and `stderr` output into individual lines before passing them to the logger. This ensures that each log entry is handled separately, improving log accuracy and display.

**TUI log tailing and scrolling:**
- Modified the effect for log tailing in `InkTUIRenderer` to always update the scroll offset when tailing is enabled and logs are present, regardless of the number of log entries. The dependency array was also updated to use `logEntries.length` for more precise effect triggering.
- Enhanced the key press handler in `InkTUIRenderer` to ensure that when a process is selected, its tailing state is correctly tracked in the `tailingMap`. This guarantees that newly selected processes start tailing logs automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Log output now displays line-by-line, avoiding stray blank lines and handling trailing newlines correctly.
  * Improved log tailing: when tailing is enabled, the view reliably auto-scrolls to new entries.
  * Pressing Enter on a selected item ensures tailing is enabled for that item and resets the log scroll offset for immediate visibility.
  * Smoother, more consistent experience when viewing growing logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->